### PR TITLE
add key schemas in to the supported list

### DIFF
--- a/schemas/membership.json
+++ b/schemas/membership.json
@@ -1,0 +1,40 @@
+{
+    "$id": "https://dedi.global/membership.json",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "Membership. This schema is used to establish membership of person/entity to a club, an entity in a larger consortium, or even can be citizenship of a country. Think of this as 'Affiliation'",
+    "type": "object",
+    "properties": {
+	"id": {
+	    "type": "string",
+	    "description": "Unique membership ID"
+	},
+	"detail": {
+	    "type": "object",
+	    "description": "Public details of the member"
+	    "properties": {
+		"name": { "type": "string" },
+		"url": { "type": "string", "format": "url"},
+		"address": { "type": "string" },
+		"publicKey": { "type": "string", "description": "this can be a url/uri pointing to DeDi public key registry entry, or even DID" },
+	    },
+	    "required": ["name"],
+	    "additionalProperties": true,
+	},
+	"evidence": {
+	    "description": "Evidence of membership (if any). Can be URL also",
+	    "type": "string"
+	},
+	"memberSince": {
+	    "type": "string",
+	    "format": "date"
+	},
+	"memberTill": {
+	    "type": "string",
+	    "format": "date"
+	}
+    },
+    "required": [ "id", "detail"],
+    "dependentRequired": {
+	"detail": [ "name" ],
+    }
+}

--- a/schemas/public_key.json
+++ b/schemas/public_key.json
@@ -9,10 +9,18 @@
 	    "type": "string",
 	    "description": "Unique ID of the entity"
 	},
-	"active": {
+	"publicKey": {
 	    "type": "string",
 	    "description": "currently active public key"
 	},
+	"keyType": {
+	    "type": "string",
+	    "description": "RSA2048, Edcsa, ed25519",
+	}
+	"keyFormat": {
+	    "type": "string",
+	    "description": "base58, base64, hex, x.509 etc etc",
+	}
 	"entity": {
 	    "type": "object",
 	    "description": "Public details of the entity"
@@ -27,9 +35,21 @@
 	"previousKeys": {
 	    "type": "array",
 	    "items": {
-		"type": "string"
+		"type": "object",
+		"properties": {
+		    "publicKey": {
+			"type": "string"
+		    },
+		    "keyType": {
+			"type": "string"
+		    },
+		    "keyFormat": {
+			"type": "string"
+		    }
+		},
+		"additionalProperties": true
 	    }
 	}
     },
-    "required": [ "id", "active"]
+    "required": [ "id", "publicKey", "keyType"]
 }

--- a/schemas/public_key.json
+++ b/schemas/public_key.json
@@ -1,0 +1,35 @@
+{
+    "$id": "https://dedi.global/public_key.json",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Public Key Directory",
+    "description": "This schema is used to get public key details from the public directory for a given entity",
+    "type": "object",
+    "properties": {
+	"id": {
+	    "type": "string",
+	    "description": "Unique ID of the entity"
+	},
+	"active": {
+	    "type": "string",
+	    "description": "currently active public key"
+	},
+	"entity": {
+	    "type": "object",
+	    "description": "Public details of the entity"
+	    "properties": {
+		"name": { "type": "string" },
+		"url": { "type": "string", "format": "url"},
+		"address": { "type": "string" },
+	    },
+	    "required": ["name"],
+	    "additionalProperties": true,
+	},
+	"previousKeys": {
+	    "type": "array",
+	    "items": {
+		"type": "string"
+	    }
+	}
+    },
+    "required": [ "id", "active"]
+}

--- a/schemas/revoke.json
+++ b/schemas/revoke.json
@@ -1,0 +1,18 @@
+{
+    "$id": "https://dedi.global/revoke.json",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Revoke or Negative List"
+    "description": "Revocation List. This schema is used to represent anything which is revoked/blacklisted aka, negative list. Examples are blacklisted entities in a country, no-fly list, list of credentials revoked from the issuance in an university",
+    "type": "object",
+    "properties": {
+	"id": {
+	    "type": "string",
+	    "description": "Unique ID which is getting revoked"
+	},
+	"reason": {
+	    "description": "Reason for revocation / blacklisting",
+	    "type": "string"
+	},
+    },
+    "required": [ "id"]
+}


### PR DESCRIPTION
These schemas are example of content of directories. We can publish key schemas which are supported in the list, so those who are parsing the lookup APIs can look at the relevant keys from the response. 