### PR TITLE
Inline registries in the manifest; record naming and addressing rules

### DIFF
--- a/docs/publishing-dedi-files.md
+++ b/docs/publishing-dedi-files.md
@@ -112,7 +112,8 @@ The trust model depends only on the first two, both of which are signed.
 
 A DeDi file carries **exactly one registry** (directory). A namespace with *N* registries publishes
 *N* files, indexed together by the manifest. Fields reuse the DeDi API's names so a server projects a
-file into a `/dedi/lookup` response without translation.
+file into a `/dedi/lookup` response without translation. A DeDi file is served as its own document,
+or — for a small registry — embedded verbatim in the manifest's `files[]` (see 6.4).
 
 ```jsonc
 {
@@ -166,6 +167,12 @@ file into a `/dedi/lookup` response without translation.
 - **`publisher.key` is public only.** Publishers sign locally; no server ever receives private key material.
 - **`records` are pure data** — `{ record_name, details }`. Lifecycle lives at the *registry* level
   (`state`) and via *negative registries*, not per record.
+- **`record_name` is REQUIRED and MUST be unique within its registry.** A file containing duplicate
+  record names is invalid and MUST be rejected. Names are case-sensitive and carry no character-set
+  restriction; a name appearing in a URL path is percent-encoded.
+- **Addressing.** Every record is addressed by the triple `{namespace}/{registry_name}/{record_name}`.
+  A DeDi server MUST expose an ingested record at exactly that triple, regardless of which file, host,
+  or manifest it was crawled from.
 - **`schema`** is a URL or an inline JSON Schema object, never anchored to a central host.
 - One file = one registry. Splitting a very large registry across multiple files (sharding) is a
   deferred extension, not part of this version.
@@ -248,6 +255,9 @@ files. It is signed, and served under the domain's TLS at the well-known path (R
 }
 ```
 
+Registry names are unique within a namespace: a manifest MUST NOT list two `files[]` entries —
+referenced or inline (6.4) — with the same registry name.
+
 ### 6.1 Self-signing and the trust anchor
 
 The manifest declares `key-1` and is signed by `key-1`. The apparent circularity is resolved by the
@@ -269,7 +279,40 @@ manages its entire key lifecycle by editing its own well-known.
 
 The whole-file digest lets the *signed* manifest vouch for each DeDi file before it is fetched, and
 lets a server detect a change (digest moved → re-fetch). It is the only place a whole-file hash is needed;
-the file's own signature secures its internal integrity.
+the file's own signature secures its internal integrity. An inline entry (6.4) carries no digest:
+the manifest's own signature covers its bytes directly.
+
+### 6.4 Inline registries
+
+An entry in `files[]` MAY, instead of referencing a file by URL, embed a **complete DeDi file object
+verbatim** — same shape, its own `proof`, its own embedded `publisher.key`. Everything about the file
+is unchanged: a server that extracts the entry holds a standard DeDi file and verifies it by the same
+five steps, and the key-membership check (step 3) is satisfied locally, since the surrounding
+manifest's `keys` are already in hand. The embedded file's `source_url` is the manifest's own
+well-known URL — that is genuinely where a fresher copy is re-fetched. An inline entry carries no
+`digest`, because the manifest's signature covers its bytes directly. An entry is a reference or an
+inline file, never both.
+
+```jsonc
+"files": [
+  { "registry": "public-keys",                    // referenced — hosted at url, committed by digest
+    "url": "https://example.org/dedi/dedi.public-keys.json",
+    "digest": "sha-256:..." },
+  { "dedi_version": "0.1", "type": "dedi-file",   // inline — a complete DeDi file, embedded verbatim
+    "source_url": "https://example.org/.well-known/dedi.index.json",
+    "next_update": "2026-07-15T10:00:00Z",
+    "publisher": { "domain": "example.org", "key": { "kid": "key-1", "...": "..." } },
+    "namespace": "example.org",
+    "registry": { "name": "trust-anchors", "...": "..." },
+    "records": [ { "record_name": "lfdt-root", "details": { "...": "..." } } ],
+    "proof": { "verification_method": "key-1", "canonicalization": "JCS", "jws": "..." } }
+]
+```
+
+Inline is intended for **small registries** — a publisher with a three-record key directory becomes
+fully conformant with a single signed document at one fixed path. As a registry grows, the publisher
+SHOULD move it out to a referenced file: the well-known is fetched by every verifier for the key
+check, and its size is a cost paid by all of them.
 
 ---
 
@@ -437,14 +480,16 @@ A GitHub repo is a convenient implementation (the directory listing is the index
 ## 13. Conformance
 
 A **publisher** conforms if it: produces DeDi files, each carrying
-`source_url` and `next_update`; serves a signed `/.well-known/dedi.index.json` declaring its current
+`source_url` and `next_update`, served at URLs it controls or embedded inline in its manifest; serves
+a signed `/.well-known/dedi.index.json` declaring its current
 key(s); is discoverable via the list and/or crawl; and expresses removals via freshness or a negative
 registry. The manifest's location is the only fixed path a publisher must honour. The filename,
 directory, and header conventions are RECOMMENDED and are not conditions of conformance.
 
 A **DeDi server** conforms if it: verifies every ingested file end-to-end including the well-known key
 check and rejects unauthenticated data; serves the publisher's original records and signatures
-unaltered; and honors freshness and registry state.
+unaltered; exposes every ingested record at its `{namespace}/{registry_name}/{record_name}` triple;
+and honors freshness and registry state.
 
 A **discovery list** conforms if it is public and lists publisher domains. It asserts nothing else.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,7 +5,7 @@ Same publisher (`example.org`) and key (`key-1`) throughout.
 
 | File | What it is |
 |---|---|
-| [`dedi.index.json`](dedi.index.json) | The publisher's `/.well-known/dedi.index.json` manifest — declares the current key and lists two registries. **The authority.** |
+| [`dedi.index.json`](dedi.index.json) | The publisher's `/.well-known/dedi.index.json` manifest — declares the current key, lists two referenced registries, and embeds a third (`trust-anchors`) inline. **The authority.** |
 | [`dedi.public-keys.json`](dedi.public-keys.json) | A positive directory: presence of a record = a valid key. |
 | [`dedi.revocations.json`](dedi.revocations.json) | A negative list: presence of a record = revoked. Same shape; polarity comes from the registry, not a per-record field. |
 | [`domains.txt`](domains.txt) | The discovery list — publisher domains, one per line, with an optional `# head:` last-changed marker. Vouches for nobody. |
@@ -23,6 +23,11 @@ https://example.org/dedi/dedi.revocations.json
 
 The `dedi.*.json` name and the `/dedi/` directory are conventions; nothing in verification or
 discovery consults them — the manifest's `files[].url` is what locates a file.
+
+The third registry, `trust-anchors`, has no hosted file: it is a complete DeDi file embedded
+**inline** in the manifest's `files[]` (see the spec's Inline registries section). Its `source_url`
+is the manifest's own well-known URL, and it carries no `digest` — the manifest's signature covers
+its bytes directly.
 
 > **Not cryptographically valid.** The `jws` and `digest` values are placeholders (marked
 > `ILLUSTRATIVE_...` where applicable) to show *shape*, not real signatures. A real file carries a

--- a/examples/dedi.index.json
+++ b/examples/dedi.index.json
@@ -12,7 +12,7 @@
     {
       "registry": "public-keys",
       "url": "https://example.org/dedi/dedi.public-keys.json",
-      "digest": "sha-256:9f2c1d4e7a8b0c3d5e6f70819293a4b5c6d7e8f90a1b2c3d4e5f60718293aebae",
+      "digest": "sha-256:9f2c1d4e7a8b0c3d5e6f70819293a4b5c6d7e8f90a1b2c3d4e5f60718293aeba",
       "schema": "https://raw.githubusercontent.com/LF-Decentralized-Trust-labs/decentralized-directory-protocol/main/schemas/public_key.json"
     },
     {
@@ -20,6 +20,34 @@
       "url": "https://example.org/dedi/dedi.revocations.json",
       "digest": "sha-256:5b1a2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f0",
       "schema": "https://raw.githubusercontent.com/LF-Decentralized-Trust-labs/decentralized-directory-protocol/main/schemas/revoke.json"
+    },
+    {
+      "dedi_version": "0.1",
+      "type": "dedi-file",
+      "source_url": "https://example.org/.well-known/dedi.index.json",
+      "next_update": "2026-07-15T10:00:00Z",
+      "publisher": {
+        "domain": "example.org",
+        "key": { "kid": "key-1", "kty": "OKP", "crv": "Ed25519", "x": "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo" }
+      },
+      "namespace": "example.org",
+      "registry": {
+        "name": "trust-anchors",
+        "schema": { "type": "object", "required": ["anchor_id", "url"], "properties": { "anchor_id": { "type": "string" }, "url": { "type": "string" } } },
+        "state": "live",
+        "updated_at": "2026-07-01T09:00:00Z"
+      },
+      "records": [
+        {
+          "record_name": "lfdt-root",
+          "details": { "anchor_id": "example.org:lfdt-root", "url": "https://example.org/anchors/lfdt-root" }
+        }
+      ],
+      "proof": {
+        "verification_method": "key-1",
+        "canonicalization": "JCS",
+        "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..ILLUSTRATIVE_DETACHED_SIGNATURE_NOT_CRYPTOGRAPHICALLY_VALID"
+      }
     }
   ],
   "proof": {

--- a/schemas/dedi-file.schema.json
+++ b/schemas/dedi-file.schema.json
@@ -2,7 +2,7 @@
   "$id": "https://raw.githubusercontent.com/LF-Decentralized-Trust-labs/decentralized-directory-protocol/main/schemas/dedi-file.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "DeDi File",
-  "description": "A self-contained, signed JSON document holding one registry (directory) and its records. Served as application/json; the dedi.<registry-name>.json filename and /dedi/ directory are RECOMMENDED conventions, not conformance requirements. Hosted by the publisher at any URL it controls; discovered, verified and served by DeDi servers. Authenticity is established by confirming publisher.key appears in the keys of the publisher's signed /.well-known/dedi.index.json. See docs/publishing-dedi-files.md. NOTE: the schema $id points at the mutable main branch and must be pinned to a release tag before release.",
+  "description": "A self-contained, signed JSON document holding one registry (directory) and its records. Served as application/json; the dedi.<registry-name>.json filename and /dedi/ directory are RECOMMENDED conventions, not conformance requirements. Hosted by the publisher at any URL it controls, or embedded verbatim as an inline entry in the manifest's files[] (shape and verification unchanged; source_url is then the manifest's well-known URL); discovered, verified and served by DeDi servers. Authenticity is established by confirming publisher.key appears in the keys of the publisher's signed /.well-known/dedi.index.json. See docs/publishing-dedi-files.md. NOTE: the schema $id points at the mutable main branch and must be pinned to a release tag before release.",
   "type": "object",
   "required": ["dedi_version", "type", "source_url", "next_update", "publisher", "namespace", "registry", "records", "proof"],
   "additionalProperties": false,
@@ -57,7 +57,7 @@
         "required": ["record_name", "details"],
         "additionalProperties": false,
         "properties": {
-          "record_name": { "type": "string", "description": "Record name; maps to {record_name}." },
+          "record_name": { "type": "string", "description": "Record name; maps to {record_name}. MUST be unique within the registry — duplicates make the file invalid. Case-sensitive; no character-set restriction; percent-encoded when used in a URL path. A record is addressed as {namespace}/{registry_name}/{record_name}." },
           "details": { "type": "object", "description": "The schema-conformant payload; same field as the DeDi API Record.details." }
         }
       }

--- a/schemas/dedi-manifest.schema.json
+++ b/schemas/dedi-manifest.schema.json
@@ -34,21 +34,30 @@
     "next_update": { "type": "string", "format": "date-time", "description": "How long a verifier may cache these keys before re-fetching; also the revocation-propagation bound." },
     "files": {
       "type": "array",
-      "description": "The DeDi files (registries) this publisher offers.",
+      "description": "The DeDi files (registries) this publisher offers. An entry is a reference (the file is hosted at url, committed to by digest) or an inline entry (a complete DeDi file object embedded verbatim), never both. Registry names MUST be unique across entries.",
       "items": {
-        "type": "object",
-        "required": ["registry", "url", "digest"],
-        "additionalProperties": false,
-        "properties": {
-          "registry": { "type": "string", "description": "Registry name." },
-          "url": { "type": "string", "format": "uri", "description": "Absolute URL where the DeDi file is hosted; may be any host the publisher controls, including one different from the manifest's own domain. Authoritative for location: filename and directory conventions are never consulted." },
-          "digest": { "type": "string", "description": "Digest of the referenced DeDi file, so this signed manifest commits to its content and changes are detectable. Prefixed algorithm, e.g. 'sha-256:...'." },
-          "schema": {
-            "description": "Optional: the registry's schema (URL or inline), echoed for discovery/filtering without fetching the file.",
-            "oneOf": [{ "type": "string", "format": "uri" }, { "type": "object" }]
+        "oneOf": [
+          {
+            "type": "object",
+            "description": "Referenced entry: the DeDi file is hosted at url.",
+            "required": ["registry", "url", "digest"],
+            "additionalProperties": false,
+            "properties": {
+              "registry": { "type": "string", "description": "Registry name." },
+              "url": { "type": "string", "format": "uri", "description": "Absolute URL where the DeDi file is hosted; may be any host the publisher controls, including one different from the manifest's own domain. Authoritative for location: filename and directory conventions are never consulted." },
+              "digest": { "type": "string", "description": "Digest of the referenced DeDi file, so this signed manifest commits to its content and changes are detectable. Prefixed algorithm, e.g. 'sha-256:...'." },
+              "schema": {
+                "description": "Optional: the registry's schema (URL or inline), echoed for discovery/filtering without fetching the file.",
+                "oneOf": [{ "type": "string", "format": "uri" }, { "type": "object" }]
+              },
+              "state": { "type": "string", "enum": ["live", "inactive"], "description": "Optional echo of the registry's state for discovery." }
+            }
           },
-          "state": { "type": "string", "enum": ["live", "inactive"], "description": "Optional echo of the registry's state for discovery." }
-        }
+          {
+            "description": "Inline entry: a complete DeDi file object embedded verbatim — its own proof and embedded key, source_url set to the manifest's well-known URL, no digest (the manifest's signature covers its bytes). Intended for small registries; verification is identical to a hosted file.",
+            "allOf": [{ "$ref": "https://raw.githubusercontent.com/LF-Decentralized-Trust-labs/decentralized-directory-protocol/main/schemas/dedi-file.json" }]
+          }
+        ]
       }
     },
     "proof": {


### PR DESCRIPTION
Follow-up to #31. Three refinements to the origin-hosted publishing model; no change to the information model or the DeDi API.

## Inline registries

A `files[]` entry in the manifest may now embed a **complete DeDi file object verbatim** instead of referencing one by URL (new section 6.4). The embedded file keeps its own `proof` and embedded `publisher.key`; its `source_url` is the manifest's well-known URL; it carries no `digest`, since the manifest's signature covers its bytes directly. Verification is identical to a hosted file, and the key-membership check is satisfied locally.

This makes the minimal adoption path a **single signed document at one fixed path**: a publisher with a small registry needs nothing beyond `/.well-known/dedi.index.json`. As a registry grows it SHOULD move out to a referenced file.

## Record naming

- `record_name` MUST be unique within its registry; duplicates make the file invalid. Names are case-sensitive, carry no character-set restriction, and are percent-encoded in URL paths.
- Registry names MUST be unique within a namespace.

## Canonical addressing

Every record is addressed by the triple `{namespace}/{registry_name}/{record_name}`; a DeDi server MUST expose an ingested record at exactly that triple, regardless of which file or host it was crawled from.

## Contents

- `docs/publishing-dedi-files.md` — new 6.4, naming/addressing rules in 5.1, conformance updates
- `schemas/dedi-manifest.schema.json` — `files[].items` becomes `oneOf(referenced | inline DeDi file)`
- `schemas/dedi-file.schema.json` — description-only updates
- `examples/` — a third registry embedded inline in `dedi.index.json`; fixes a malformed 65-character placeholder digest
